### PR TITLE
apply filter to html element instead of body

### DIFF
--- a/content.js
+++ b/content.js
@@ -143,9 +143,9 @@ function applyFilter(name) {
 		"sepia": "sepia(100%)"
 	};
 	if (name && filters[name]) {
-		document.body.style.filter = filters[name];
+		document.documentElement.style.filter = filters[name];
 	} else {
-		document.body.style.filter = "none";
+		document.documentElement.style.filter = "none";
 	}
 }
 


### PR DESCRIPTION
[CSS filters break positioning of children](https://stackoverflow.com/questions/52937708/why-does-applying-a-css-filter-on-the-parent-break-the-child-positioning) and one way to fix this is to [apply the filter to the html element instead](https://stackoverflow.com/questions/53223131/positon-fixed-is-not-working-with-css-blur-filter)

should fix #237, #132, #261

This change has a regression: in Chrome dark mode the `opacity` filter will fade to white instead of black. I am not sure if this is a big problem and it could be solved by adding a similar filter that uses `brightness` instead.